### PR TITLE
Added description + Formatting of summary

### DIFF
--- a/lectocal/gcalendar.py
+++ b/lectocal/gcalendar.py
@@ -146,7 +146,11 @@ def _parse_event_to_lesson(event):
         location = event["location"]
     else:
         location = None
-    return lesson.Lesson(id, summary, status, start, end, location)
+    if "description" in event:
+        description = event["description"]
+    else:
+        description = None
+    return lesson.Lesson(id, summary, status, start, end, location, description)
 
 
 def _parse_events_to_schedule(events):

--- a/lectocal/lectio.py
+++ b/lectocal/lectio.py
@@ -167,7 +167,9 @@ def _get_info_from_title(title):
     status = start_time = end_time = location = None
     lines = title.split("\n")
     for line in lines:
-        if _is_status_line(line):
+        if line == "":
+            break
+        elif _is_status_line(line):
             status = _get_status_from_line(line)
         elif _is_time_line(line):
             start_time, end_time = _get_time_from_line(line)

--- a/lectocal/lectio.py
+++ b/lectocal/lectio.py
@@ -155,29 +155,41 @@ def _get_time_from_line(line):
     return start, end
 
 
-def _add_line_to_summary(line, summary):
-    if summary != "":
-        summary += "\n"
-    summary += line
+def _add_line_to_text(line, text):
+    if text != "":
+        text += "\n"
+    text += line
+    return text
+
+
+def _add_section_to_summary(section, summary):
+    if summary != "" and section != "":
+        summary += " " + u"\u2022" + " "
+    summary += section
     return summary
 
 
 def _get_info_from_title(title):
-    summary = ""
+    summary = description = ""
     status = start_time = end_time = location = None
-    lines = title.split("\n")
+    lines = title.splitlines()
+    headerSection = True
     for line in lines:
-        if line == "":
-            break
-        elif _is_status_line(line):
-            status = _get_status_from_line(line)
-        elif _is_time_line(line):
-            start_time, end_time = _get_time_from_line(line)
-        elif _is_location_line(line):
-            location = _get_location_from_line(line)
+        if headerSection:
+            if line == '':
+                headerSection = False
+                continue
+            if _is_status_line(line):
+                status = _get_status_from_line(line)
+            elif _is_time_line(line):
+                start_time, end_time = _get_time_from_line(line)
+            elif _is_location_line(line):
+                location = _get_location_from_line(line)
+            else:
+                summary = _add_section_to_summary(line, summary)
         else:
-            summary = _add_line_to_summary(line, summary)
-    return summary, status, start_time, end_time, location
+            description = _add_line_to_text(line, description)
+    return summary, status, start_time, end_time, location, description
 
 
 def _parse_element_to_lesson(element):
@@ -185,9 +197,9 @@ def _parse_element_to_lesson(element):
     id = None
     if link:
         id = _get_id_from_link(link)
-    summary, status, start_time, end_time, location = \
+    summary, status, start_time, end_time, location, description = \
         _get_info_from_title(element.get("title"))
-    return lesson.Lesson(id, summary, status, start_time, end_time, location)
+    return lesson.Lesson(id, summary, status, start_time, end_time, location, description)
 
 
 def _parse_page_to_lessons(page):

--- a/lectocal/lesson.py
+++ b/lectocal/lesson.py
@@ -20,12 +20,13 @@ STATUS_COLORS = {"normal": "10", "changed": "5", "cancelled": "11"}
 
 
 class Lesson(object):
-    def __init__(self, id, summary, status, start, end, location):
+    def __init__(self, id, summary, status, start, end, location, description):
         self.summary = summary
         self.status = status or "normal"
         self.start = start
         self.end = end
         self.location = location
+        self.description = description
 
         if id is None:
             self.id = self._gen_id()
@@ -43,7 +44,8 @@ class Lesson(object):
             "end": {
                 "timeZone": "Europe/Copenhagen"
             },
-            "location": None
+            "location": None,
+            "description": None
 
         }
 
@@ -60,12 +62,13 @@ class Lesson(object):
         else:
             formatted["end"]["date"] = self.end.isoformat()
         formatted["location"] = self.location
+        formatted["description"] = self.description
         return formatted
 
     def _gen_id(self):
         lesson_string = str(self.summary) + str(self.status) + \
                         str(self.start) + str(self.end) + \
-                        str(self.location)
+                        str(self.location) + str(self.description)
         hasher = hashlib.sha256()
         hasher.update(bytes(lesson_string, "utf8"))
         hash_value = hasher.hexdigest()
@@ -82,7 +85,8 @@ class Lesson(object):
     def __repr__(self):
         return str({"id": self.id, "summary": self.summary,
                     "status": self.status, "start": self.start,
-                    "end": self.end, "location": self.location})
+                    "end": self.end, "location": self.location,
+                    "description": self.description})
 
 
 def schedules_are_identical(schedule1, schedule2):


### PR DESCRIPTION
Since homework and notes cluttered the summary, this pull request adds everything after the first empty line to the description field in Google Calendar instead. In addition, the attempt at line-breaks in the summary has been replaced with small dots (Unicode character 2022) as these are actually rendered in the calendar (in a web browser at least).