### PR TITLE
New Lectio HTML structure

### DIFF
--- a/lectocal/lectio.py
+++ b/lectocal/lectio.py
@@ -202,7 +202,7 @@ def _parse_element_to_lesson(element):
         id = _get_id_from_link(link)
         link = _get_complete_link(link)
     summary, status, start_time, end_time, location, description = \
-        _get_info_from_title(element.get("title"))
+        _get_info_from_title(element.get("data-additionalinfo"))
     return lesson.Lesson(id, summary, status, start_time, end_time, location, description, link)
 
 


### PR DESCRIPTION
Lectio has switched from using the 'title' attribute to 'data-additionalInfo' for holding lesson information.
Example:
```html
<a href='/lectio/...' class="s2skemabrik s2bgbox s2withlink lec-context-menu-instance" style="..." data-additionalInfo="4/1-2018 08:00 til 09:40
Hold: 3g Fy
Lærer: Peter Pedal (PP)
Lokale: FYL">
```
This causes the current version of the script to fail with this error:
```
File "/home/pp/.local/lib/python3.6/site-packages/lectocal/lectio.py", line 178, in _get_info_from_title
    lines = title.splitlines()
AttributeError: 'NoneType' object has no attribute 'splitlines'
```
This pull request just changes the attribute name from 'title' to 'data-additionalinfo' to fix the error.