### PR TITLE
Switched to HTTPS and added ProeveholdId

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ institutions using lectio to stay on top of their schedules, by allowing
 the use of features such as email notifications, and push notifications
 on Android and iOS devices, together with the lectio schedule.
 
-.. _Lectio: http://www.lectio.dk/
+.. _Lectio: https://www.lectio.dk/
 .. _`Google Calendar`: https://calendar.google.com/
 
 Installation
@@ -161,7 +161,7 @@ The positional arguments are:
     in Lectio's system.
 
     It can be found by browsing to your school's front page (eg.
-    http://www.lectio.dk/lectio/523/default.aspx), the school id is the number
+    https://www.lectio.dk/lectio/523/default.aspx), the school id is the number
     in the page URL, in my case 523.
 
 - user_type
@@ -177,7 +177,7 @@ The positional arguments are:
     Both of these id types are used as user_id in lectocal.
 
     To find the id of a user, open their schedule page (eg.
-    http://www.lectio.dk/lectio/523/SkemaNy.aspx?type=elev&elevid=2486079338)
+    https://www.lectio.dk/lectio/523/SkemaNy.aspx?type=elev&elevid=2486079338)
     the user id number, is the number behind elevid= or laererid= depending
     on the user type, in this case 2486079338.
 

--- a/lectocal/lectio.py
+++ b/lectocal/lectio.py
@@ -65,7 +65,7 @@ def _get_lectio_weekformat_with_offset(offset):
 
 
 def _get_id_from_link(link):
-    match = re.search("absid|ProeveholdId=(\d+)", link)
+    match = re.search("(?:absid|ProeveholdId)=(\d+)", link)
     if match is None:
         raise IdNotFoundInLinkError("Couldn't find id in link: {}".format(
                                     link))

--- a/lectocal/lectio.py
+++ b/lectocal/lectio.py
@@ -44,7 +44,7 @@ class InvalidLocationError(Exception):
 
 
 def _get_user_page(school_id, user_type, user_id, week=""):
-    URL_TEMPLATE = "http://www.lectio.dk/lectio/{0}/" \
+    URL_TEMPLATE = "https://www.lectio.dk/lectio/{0}/" \
                    "SkemaNy.aspx?type={1}&{1}id={2}&week={3}"
 
     r = requests.get(URL_TEMPLATE.format(school_id,
@@ -65,14 +65,14 @@ def _get_lectio_weekformat_with_offset(offset):
 
 
 def _get_id_from_link(link):
-    match = re.search("absid=(\d+)", link)
+    match = re.search("absid|ProeveholdId=(\d+)", link)
     if match is None:
         raise IdNotFoundInLinkError("Couldn't find id in link: {}".format(
                                     link))
     return match.group(1)
 
 def _get_complete_link(link):
-    return "http://www.lectio.dk" + link.split("&prevurl=", 1)[0]
+    return "https://www.lectio.dk" + link.split("&prevurl=", 1)[0]
 
 
 def _is_status_line(line):


### PR DESCRIPTION
Lectio has switched to using HTTPS so a request to http://lectio.dk results in a `301 Moved permanently` return code.
This PR switches the script over to HTTPS and adds support for a new ID, `ProeveholdId`, which is sometimes used instead of `absid`.