### PR TITLE
Bugfix py3.7 builds failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,7 @@ script:
 after_success:
   - coverage report
   - coveralls
+notifications:
+  email:
+    on_failure: always
+    on_success: never

--- a/Pipfile
+++ b/Pipfile
@@ -15,6 +15,3 @@ requests = "*"
 lxml = "*"
 python-dateutil = "*"
 pytz = "*"
-
-[requires]
-python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -4,9 +4,6 @@
             "sha256": "34c77ce064fdd4b3bc3821a8f26eb3a31a20b356fae0f8d4dc62abee5d22ef9f"
         },
         "pipfile-spec": 6,
-        "requires": {
-            "python_version": "3.6"
-        },
         "sources": [
             {
                 "name": "pypi",


### PR DESCRIPTION
Fixes python 3.7 builds failing, by removing the required version in pipenv.