### PR TITLE
Add backoff, add login with password, and add cookie handling.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,3 +16,6 @@ lxml = "*"
 python-dateutil = "*"
 pytz = "*"
 oauth2client = "*"
+backoff = "*"
+pickle = "*"
+

--- a/lectocal/gcalendar.py
+++ b/lectocal/gcalendar.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import backoff
 import datetime
 from httplib2 import Http
 import dateutil.parser
@@ -173,28 +174,22 @@ def get_schedule(google_credentials, calendar_name, n_weeks):
     events = _get_events_in_date_range(service, calendar_id, start, end)
     return _parse_events_to_schedule(events)
 
-
+@backoff.on_exception(backoff.expo, HttpError,  max_tries=8)
 def _delete_lesson(service, calendar_id, lesson_id):
     service \
         .events() \
         .delete(calendarId=calendar_id, eventId=lesson_id) \
         .execute()
 
-
+@backoff.on_exception(backoff.expo, HttpError,  max_tries=4)
 def _add_lesson(service, calendar_id, lesson):
-    try:
-        service \
-            .events() \
-            .insert(calendarId=calendar_id, body=lesson.to_gcalendar_format()) \
-            .execute()
-    except HttpError as err:
-        #Status code 409 is conflict. In this case, it means the id already exists.
-        if err.resp.status == 409:
-            _update_lesson(service, calendar_id, lesson)
-        else:
-            raise err
+    # try:
+    service \
+        .events() \
+        .insert(calendarId=calendar_id, body=lesson.to_gcalendar_format()) \
+        .execute()
 
-
+@backoff.on_exception(backoff.expo, HttpError,  max_tries=8)
 def _update_lesson(service, calendar_id, lesson):
     service \
         .events() \
@@ -207,15 +202,22 @@ def _update_lesson(service, calendar_id, lesson):
 def _delete_removed_lessons(service, calendar_id, old_schedule, new_schedule):
     for old_lesson in old_schedule:
         if not any(new_lesson.id == old_lesson.id
-                   for new_lesson in new_schedule):
-            _delete_lesson(service, calendar_id, old_lesson.id)
+            for new_lesson in new_schedule):
+                _delete_lesson(service, calendar_id, old_lesson.id)
 
 
 def _add_new_lessons(service, calendar_id, old_schedule, new_schedule):
     for new_lesson in new_schedule:
         if not any(old_lesson.id == new_lesson.id
-                   for old_lesson in old_schedule):
-            _add_lesson(service, calendar_id, new_lesson)
+            for old_lesson in old_schedule):
+                try:
+                    _add_lesson(service, calendar_id, new_lesson)
+                except HttpError as err:
+                    #Status code 409 is conflict. In this case, it means the id already exists.
+                    if err.resp.status == 409:
+                        _update_lesson(service, calendar_id, lesson)
+                    else:
+                        raise err
 
 
 def _update_current_lessons(service, calendar_id, old_schedule, new_schedule):

--- a/lectocal/lectio.py
+++ b/lectocal/lectio.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import datetime
+import pickle
 import re
 import requests
 from lxml import html
@@ -43,15 +44,53 @@ class InvalidLocationError(Exception):
     """ The line doesn't include any location. """
 
 
-def _get_user_page(school_id, user_type, user_id, week=""):
+def _get_user_page(school_id, user_type, user_id, week = "", login = "", password = ""):
     URL_TEMPLATE = "https://www.lectio.dk/lectio/{0}/" \
                    "SkemaNy.aspx?type={1}&{1}id={2}&week={3}"
+                   
+    LOGIN_URL = "https://www.lectio.dk/lectio/{0}/login.aspx".format(school_id)
+    
+    # Start requests session
+    s = requests.Session()
+    
+    if(login != ""):
+        # Get eventvalidation key
+        result = s.get(LOGIN_URL)
+        tree = html.fromstring(result.text)
+        authenticity_token = list(set(tree.xpath("//input[@name='__EVENTVALIDATION']/@value")))[0]
 
-    r = requests.get(URL_TEMPLATE.format(school_id,
-                                         USER_TYPE[user_type],
-                                         user_id,
-                                         week),
+        # Create payload
+        payload = {
+            "m$Content$username2": login,
+            "m$Content$password2": password,
+            "m$Content$passwordHidden": password,
+            "__EVENTVALIDATION": authenticity_token,
+            "__EVENTTARGET": "m$Content$submitbtn2",
+            "__EVENTARGUMENT": "",
+            "LectioPostbackId": ""
+        }
+
+        # Perform login
+        result = s.post(LOGIN_URL, data = payload, headers = dict(referer = LOGIN_URL))
+        
+        # Save cookies to file
+        with open('cookie.txt', 'wb') as f:
+            pickle.dump(s.cookies, f)
+        
+    else:
+        # Load cookies from file
+        with open('cookie.txt', 'rb') as f:
+            s.cookies.update(pickle.load(f))
+        
+    # Scrape url and save cookies to file
+    r = s.get(URL_TEMPLATE.format(school_id,
+                                  USER_TYPE[user_type],
+                                  user_id,
+                                  week),
                      allow_redirects=False)
+    with open('cookie.txt', 'wb') as f:
+        pickle.dump(s.cookies, f)
+        
     return r
 
 
@@ -65,7 +104,7 @@ def _get_lectio_weekformat_with_offset(offset):
 
 
 def _get_id_from_link(link):
-    match = re.search("(?:absid|ProeveholdId|outboundCensorID)=(\d+)", link)
+    match = re.search("(?:absid|ProeveholdId|outboundCensorID|aftaleid)=(\d+)", link)
     if match is None:
         raise IdNotFoundInLinkError("Couldn't find id in link: {}".format(
                                     link))
@@ -218,8 +257,8 @@ def _parse_page_to_lessons(page):
     return lessons
 
 
-def _retreive_week_schedule(school_id, user_type, user_id, week):
-    r = _get_user_page(school_id, user_type, user_id, week)
+def _retreive_week_schedule(school_id, user_type, user_id, week, login = "", password = ""):
+    r = _get_user_page(school_id, user_type, user_id, week, login = "", password = "")
     schedule = _parse_page_to_lessons(r.content)
     return schedule
 
@@ -232,27 +271,29 @@ def _filter_for_duplicates(schedule):
     return filtered_schedule
 
 
-def _retreive_user_schedule(school_id, user_type, user_id, n_weeks):
+def _retreive_user_schedule(school_id, user_type, user_id, n_weeks, login = "", password = ""):
     schedule = []
     for week_offset in range(n_weeks + 1):
         week = _get_lectio_weekformat_with_offset(week_offset)
         week_schedule = _retreive_week_schedule(school_id,
                                                 user_type,
                                                 user_id,
-                                                week)
+                                                week, 
+                                                login = "", 
+                                                password = "")
         schedule += week_schedule
     filtered_schedule = _filter_for_duplicates(schedule)
     return filtered_schedule
 
 
-def _user_exists(school_id, user_type, user_id):
-    r = _get_user_page(school_id, user_type, user_id)
+def _user_exists(school_id, user_type, user_id, login = "", password = ""):
+    r = _get_user_page(school_id, user_type, user_id, "", login, password)
     return r.status_code == requests.codes.ok
 
 
-def get_schedule(school_id, user_type, user_id, n_weeks):
-    if not _user_exists(school_id, user_type, user_id):
+def get_schedule(school_id, user_type, user_id, n_weeks, login = "", password = ""):
+    if not _user_exists(school_id, user_type, user_id, login, password):
         raise UserDoesNotExistError("Couldn't find user - school: {}, "
-                                    "type: {}, id: {} - in Lectio.".format(
-                                        school_id, user_type, user_id))
-    return _retreive_user_schedule(school_id, user_type, user_id, n_weeks)
+                                    "type: {}, id: {}, login: {} - in Lectio.".format(
+                                        school_id, user_type, user_id, login))
+    return _retreive_user_schedule(school_id, user_type, user_id, n_weeks, login = "", password = "")

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,9 @@ setup(
         "lxml",
         "pytz",
         "python-dateutil",
-        "oauth2client"
+        "oauth2client",
+        "backoff",
+        "pickle"
     ],
     package_data={
         "lectocal": [


### PR DESCRIPTION
Add backoff: To avoid exceptions from due to ?timeouts? from the Google Calendar API.

Add login with password: The new flag "--login" takes the username from Lectio. If this flag is set then the user is asked for his/her password in the typical command-line way.

Add cookie handling: Upon succesful login the cookie is save to file. The calendar can then be updated without the "--login" flag until the Lectio session expires. The "--keepalive" flag is designed to be run such that session does not expire. It sufficient to run the script with "--keepalive" every 50 minutes, however, the session will expire every night.